### PR TITLE
Wine labels fix

### DIFF
--- a/Assets/External/HexToBinary_LICENSE.txt
+++ b/Assets/External/HexToBinary_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 C.S. Melis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.iss
+++ b/setup.iss
@@ -141,7 +141,7 @@ begin
         Process_FreelancerLogo();
         Process_SmallText();
         Process_Console();
-        Process_BestOptions(); // Must be called after Process_NewSaveFolder();
+        Process_BestOptions();
         Process_Effects();
         Process_SkipIntros();
         Process_JumpTunnelDurations();
@@ -149,9 +149,9 @@ begin
         Process_Planetscape();
         Process_Win10();
         Process_HUD();
-        Process_DarkHUD(); // Must be called after Process_HUD();
+        Process_DarkHUD(); 
         Process_FlatIcons();
-        Process_WeaponGroups();
+        Process_WeaponGroups(); // Must be called after Process_HUD();
         Process_DxWrapper();
         Process_DxWrapperReShade();
         Process_DgVoodooReShade();

--- a/setup.iss
+++ b/setup.iss
@@ -81,16 +81,17 @@ WelcomeLabel2=Freelancer: HD Edition is a mod that aims to improve every aspect 
 FinishedLabel=Setup has finished installing [name] on your computer. The application may be launched by selecting the installed shortcut.%n%nNOTE: [name] has been installed as a separate application. Therefore, your vanilla Freelancer installation has not been modified and can still be played at any time.
 
 [Code]
+# if !AllInOneInstall
 // Declaration of global variables
 var
   // Allows us to skip the downloading of the files and just copy it from the local PC to save time
   OfflineInstall: String;
-  # if !AllInOneInstall
+
   // String list of mirrors that we can potentially download the mod from. This is populated in InitializeWizard()
   mirrors : TStringList;
   // Size of Download in MB
   DownloadSize : String;
-  #endif
+#endif
 
 // Imports from other .iss files
 #include "utilities.iss"
@@ -222,8 +223,8 @@ begin
 
     // If they specify an offline file in the cmd line. Check it's valid, if not don't let them continue.
     # if !AllInOneInstall
-    if ((PageId = 1) and (OfflineInstall <> 'false') and (not FileExists(OfflineInstall) or (Pos('.zip',OfflineInstall) < 1))) then begin
-      MsgBox('The specified source file either doesn''t exist or is not a valid .zip file', mbError, MB_OK);
+    if ((PageId = 1) and (OfflineInstall <> 'false') and (not FileExists(OfflineInstall) or (Pos('.7z',OfflineInstall) < 1))) then begin
+      MsgBox('The specified source file either doesn''t exist or is not a valid .7z file', mbError, MB_OK);
       Result := False;
       exit;
     end;
@@ -282,10 +283,10 @@ end;
 // Run when the wizard is opened.
 procedure InitializeWizard;
 begin
-    // Offline install
-    OfflineInstall := ExpandConstant('{param:sourcefile|false}')
-
     # if !AllInOneInstall
+      // Offline install
+      OfflineInstall := ExpandConstant('{param:sourcefile|false}')
+
       // Copy mirrors from our preprocessor to our string array. This allows us to define the array at the top of the file for easy editing
       mirrors := TStringList.Create;
    

--- a/ui.iss
+++ b/ui.iss
@@ -676,7 +676,7 @@ begin
   DxWrapperAf.Items.Add('16x');
   DxWrapperAf.Items.Add('Auto (recommended)');
   DxWrapperAf.ItemIndex := 5;
-  DxWrapperAf.Top := lblDxWrapperAf.Top + ScaleY(25);
+  DxWrapperAf.Top := lblDxWrapperAf.Top + ScaleY(20);
 
   descDxWrapperAf := TNewStaticText.Create(DxWrapperPage);
   descDxWrapperAf.Parent := DxWrapperPage.Surface;

--- a/ui.iss
+++ b/ui.iss
@@ -243,7 +243,9 @@ begin
 end;
 
 procedure InitializeUi();
-var dir : string;
+var 
+  dir : string;
+  CheckBoxWidth: Integer;
 begin
   # if !AllInOneInstall
   // Read download size
@@ -1183,8 +1185,48 @@ begin
     OnClick := @DgVoodooReShadeCheckBoxClick;
   end;
 
-  // TODO: Remove when the Wine label issue has been fixed
+  // Make all the custom checkboxes and radio buttons less wide so the clickable area doesn't hide the accompanying labels.
   if (IsWine) then
-    MsgBox('It seems you are using Wine. The installer will still work as intended. One minor issue is that many option labels won''t be displayed correctly, presumably because of an incorrect API translation.'  + #13#10#13#10 +
-    'We''ve uploaded screenshots of all installer pages on https://freelancerhd.com/install. Hopefully this will help.', mbError, MB_OK);
+  begin
+    CheckBoxWidth := ScaleX(20)
+
+    // Checkboxes
+    EnglishImprovements.Width := CheckBoxWidth
+    NewSaveFolder.Width := CheckBoxWidth
+    WidescreenHud.Width := CheckBoxWidth
+    WeaponGroups.Width := CheckBoxWidth
+    DarkHud.Width := CheckBoxWidth
+    FlatIcons.Width := CheckBoxWidth
+    PlanetScape.Width := CheckBoxWidth
+    DxWrapperReShade.Width := CheckBoxWidth
+    DxWrapperSaturation.Width := CheckBoxWidth
+    DxWrapperHdr.Width := CheckBoxWidth
+    DxWrapperBloom.Width := CheckBoxWidth
+    DgVoodooReShade.Width := CheckBoxWidth
+    DgVoodooSaturation.Width := CheckBoxWidth
+    DgVoodooHdr.Width := CheckBoxWidth
+    DgVoodooBloom.Width := CheckBoxWidth
+    MissileEffects.Width := CheckBoxWidth
+    EngineTrails.Width := CheckBoxWidth
+    SkipIntros.Width := CheckBoxWidth
+    SinglePlayer.Width := CheckBoxWidth
+    BestOptions.Width := CheckBoxWidth
+    DoNotPauseOnAltTab.Width := CheckBoxWidth
+
+    // Radio buttons
+    StoryMode.Width := CheckBoxWidth
+    OspNormal.Width := CheckBoxWidth
+    OspPirate.Width := CheckBoxWidth
+    DxWrapperGraphicsApi.Width := CheckBoxWidth
+    DgVoodooGraphicsApi.Width := CheckBoxWidth
+    VanillaGraphicsApi.Width := CheckBoxWidth
+    LightingFixGraphicsApi.Width := CheckBoxWidth
+    VanillaReflections.Width := CheckBoxWidth
+    ShinyReflections.Width := CheckBoxWidth
+    ShiniestReflections.Width := CheckBoxWidth
+    JumpTunnel10Sec.Width := CheckBoxWidth
+    JumpTunnel5Sec.Width := CheckBoxWidth
+    JumpTunnel2Sec.Width := CheckBoxWidth
+    JumpTunnelSkip.Width := CheckBoxWidth
+  end;
 end;

--- a/ui.iss
+++ b/ui.iss
@@ -252,20 +252,19 @@ begin
   DownloadPage := CreateDownloadPage(SetupMessage(msgWizardPreparing), SetupMessage(msgPreparingDesc), @OnDownloadProgress);
   # endif
 
+  dir := 'C:\Program Files (x86)\Microsoft Games\Freelancer'
+
   // Initialize DataDirPage and add content
   DataDirPage := CreateInputDirPage(wpInfoBefore,
   'Select Freelancer installation', 'Where is Freelancer installed?',
-  'Select the folder in which a fresh and completely unmodded copy of Freelancer is installed. This is usually C:\Program Files (x86)\Microsoft Games\Freelancer.'  + #13#10 +
+  'Select the folder in which a fresh and completely unmodded copy of Freelancer is installed. This is usually ' + dir + '.' + #13#10 +
   'The folder you select here will be copied without modification.',
   False, '');
   DataDirPage.Add('');
   
-  if RegQueryStringValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Wow6432Node\Microsoft\Microsoft Games\Freelancer\1.0',
-  'AppPath', dir) then
-  begin
-  // If the Reg key exists, populate the folder location box
-    DataDirPage.Values[0] := dir
-  end;
+  // If the Reg key exists, use its content to populate the folder location box. Use the default path if othwerise.
+  RegQueryStringValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Wow6432Node\Microsoft\Microsoft Games\Freelancer\1.0', 'AppPath', dir)
+  DataDirPage.Values[0] := dir
   
   // Initialize CallSign page and add content
   CallSign := CreateInputOptionPage(DataDirPage.ID,


### PR DESCRIPTION
This pull request adds the following:
- Fixed the Wine label overlay issue, closes #72.
- Sets the default Program Files path for the Freelancer installation if the reg key hasn't been found.
- Adjust DxWrapper AF combo box position.
- Fix documentation for the order of processing options.
- Add license for the external Hex To Binary DLL.
- Do not decelerate the OfflineInstall variable when it's not needed.